### PR TITLE
Initial implementation of `TransferFunction`

### DIFF
--- a/src/eztaox/kernels/eqx_utils.py
+++ b/src/eztaox/kernels/eqx_utils.py
@@ -1,0 +1,26 @@
+import equinox as eqx
+import jax
+from equinox._module import BoundMethod
+from jax.tree_util import GetAttrKey
+
+
+def find_param_by_name(module: eqx.Module, name: str) -> list | None:
+    """Find a leaf parameter in an Equinox module by name.
+
+    Args:
+        module: The Equinox module to search in.
+        name: The name of the parameter to find.
+
+    Returns:
+        The parameter if found, None otherwise.
+    """
+    leaves_with_paths = jax.tree_util.tree_leaves_with_path(module)
+
+    leaves = []
+    for path, leaf in leaves_with_paths:
+        if path and not isinstance(leaf, BoundMethod):
+            last_key = path[-1]
+            if isinstance(last_key, GetAttrKey) and last_key.name == name:
+                leaves.append(leaf)
+
+    return leaves if len(leaves) > 0 else None

--- a/src/eztaox/kernels/transfer_function.py
+++ b/src/eztaox/kernels/transfer_function.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+
+import equinox as eqx
+import jax
+import tinygp
+from jax import numpy as jnp
+from tinygp.helpers import JAXArray
+
+from eztaox.kernels.eqx_utils import find_param_by_name
+from eztaox.kernels.quasisep import Quasisep
+
+
+class TransferFunction(eqx.Module):
+    """Base class for transfer functions Ψ(Δt).
+
+    Normalized so that ∫₋∞^∞ Ψ(Δt) dΔt = 1.
+    """
+
+    width: float
+    shift: JAXArray | float = eqx.field(default_factory=lambda: jnp.zeros(()))
+
+    @abstractmethod
+    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
+        """Evaluate the transfer function at two points."""
+        del X1, X2
+        raise NotImplementedError
+
+
+class GaussianTransferFunction(TransferFunction):
+    """Gaussian transfer function: Ψ(s) ∝ exp(-((s - shift)/w)²)."""
+
+    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
+        """Evaluate the normalized transfer function at two points.
+
+        Normalized so that ∫₋∞^∞ Ψ(s) ds = 1.
+        """
+        dt = X2 - X1 - self.shift
+        norm = jnp.sqrt(jnp.pi) * self.width
+        return jnp.exp(-jnp.square(dt / self.width)) / norm
+
+
+class ExponentialTransferFunction(TransferFunction):
+    """Exponential transfer function: Ψ(s) = (1/w) exp(-|s - shift|/w)."""
+
+    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
+        """Evaluate the normalized transfer function at two points.
+
+        Normalized so that ∫₋∞^∞ Ψ(s) ds = 1.
+        """
+        dt = X2 - X1 - self.shift
+        norm = 2.0 * self.width
+        return jnp.exp(-jnp.abs(dt) / self.width) / norm
+
+
+class CausalGaussianTransferFunction(TransferFunction):
+    """Causal Gaussian transfer function.
+
+    Ψ(s) ∝ exp(-((s - shift)/w)²) for s ≥ 0, zero otherwise.
+    """
+
+    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
+        """Evaluate the normalized transfer function at two points.
+
+        Normalized so that ∫₋∞^∞ Ψ(s) ds = 1 for any shift.
+        """
+        ds = X2 - X1
+        dt = ds - self.shift
+        norm = (
+            jnp.sqrt(jnp.pi)
+            / 2
+            * self.width
+            * (1 + jax.scipy.special.erf(self.shift / self.width))
+        )
+        return jnp.where(ds >= 0, jnp.exp(-jnp.square(dt / self.width)) / norm, 0.0)
+
+
+class CausalExponentialTransferFunction(TransferFunction):
+    """Causal exponential transfer function.
+
+    Ψ(s) = (1/w) exp(-(s - shift)/w) for s ≥ shift, zero otherwise.
+    """
+
+    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
+        """Evaluate the normalized transfer function at two points.
+
+        Normalized so that ∫₋∞^∞ Ψ(s) ds = 1 for any shift ≥ 0.
+        """
+        dt = X2 - X1 - self.shift
+        return jnp.where(dt >= 0, jnp.exp(-dt / self.width) / self.width, 0.0)
+
+
+class ConvolvedKernel(tinygp.kernels.Kernel):
+    """Kernel convolved with a transfer function via FFT.
+
+    Computes the convolved kernel using the Wiener-Khinchin relation:
+        S_conv(f) = S_base(f) × |Ψ̂(f)|²
+        k_conv(τ) = IFFT[S_conv](τ)
+
+    where Ψ̂ is the Fourier transform of the transfer function and
+    S_base is the power spectral density of the base kernel.
+    """
+
+    # We actually need .power(), so it could be extended to "direct" kernels
+    base_kernel: Quasisep
+    transfer_function: TransferFunction
+    n_grid: int = eqx.field(static=True)
+    truncation_factor: float = eqx.field(static=True, default=6.0)
+
+    def coord_to_sortable(self, X) -> JAXArray:  # noqa: D102
+        return X[0]
+
+    @property
+    def _half_width(self):
+        """Half-width of integration grid around center."""
+        scales = find_param_by_name(self.base_kernel, "scale")
+        scale = sum(scales) / len(scales)
+        width = self.transfer_function.width
+        return (scale + width) * self.truncation_factor
+
+    @property
+    def _center(self):
+        """Center of integration grid."""
+        return self.transfer_function.shift
+
+    def evaluate(self, X1, X2) -> JAXArray:  # noqa: D102
+        tau = jnp.abs(X1 - X2)
+
+        hw = self._half_width
+        center = self._center
+        n = self.n_grid
+
+        # Uniform grid covering the TF support with zero-padding (2× support)
+        grid_len = 4 * hw
+        ds = grid_len / n
+        s_grid = center - 2 * hw + jnp.arange(n) * ds
+
+        # Evaluate Ψ on the grid
+        zero = jnp.zeros(n)
+        psi_vals = self.transfer_function.evaluate(zero, s_grid)
+
+        # FFT-based computation: S_conv(f) = S_base(f) × |Ψ̂(f)|²
+        psi_fft = jnp.fft.rfft(psi_vals)
+        freqs = jnp.fft.rfftfreq(n, d=ds)
+        psd_base = self.base_kernel.power(freqs)
+        psd_conv = psd_base * jnp.abs(psi_fft) ** 2
+
+        # IFFT → k_conv on uniform lag grid
+        k_conv = ds * jnp.fft.irfft(psd_conv, n=n)
+
+        # Interpolate at desired lag (first half = non-negative lags)
+        n_half = n // 2 + 1
+        tau_grid = jnp.arange(n_half) * ds
+
+        return jnp.interp(tau, tau_grid, k_conv[:n_half])

--- a/tests/test_transfer_function.py
+++ b/tests/test_transfer_function.py
@@ -1,0 +1,96 @@
+import jax.numpy as jnp
+import pytest
+from tinygp.test_utils import assert_allclose
+
+from eztaox.kernels import quasisep
+from eztaox.kernels.transfer_function import (
+    CausalExponentialTransferFunction,
+    CausalGaussianTransferFunction,
+    ConvolvedKernel,
+    ExponentialTransferFunction,
+    GaussianTransferFunction,
+    TransferFunction,
+)
+
+
+def _analytic_convolved_exp(dt, tau, w):
+    """Analytic result for Exp kernel convolved with exponential transfer function.
+
+    K_conv(Δt) = A exp(-|Δt|/τ) - B exp(-|Δt|/w) - C |Δt| exp(-|Δt|/w)
+
+    where D = τ² - w², A = τ⁴/D², B = wτ(3τ²-w²)/2D², C = τ/2D.
+
+    The base kernel is Exp(scale=τ): K(Δt) = exp(-|Δt|/τ).
+    The transfer function is Ψ(Δt) = (1/w) exp(-|Δt|/w).
+    Requires τ ≠ w.
+    """
+    abs_dt = jnp.abs(dt)
+    D = tau**2 - w**2
+    A = tau**4 / D**2
+    B = 0.5 * w * tau * (3 * tau**2 - w**2) / D**2
+    C = 0.5 * tau / D
+    return (
+        A * jnp.exp(-abs_dt / tau)
+        - B * jnp.exp(-abs_dt / w)
+        - C * abs_dt * jnp.exp(-abs_dt / w)
+    )
+
+
+def test_convolved_kernel_analytic():
+    """Test ConvolvedKernel against analytic result for Exp + exponential TF."""
+    lags = jnp.array([0.0, 1.0, 5.0, 10.0, 50.0, 100.0, 200.0])
+
+    for tau, w in [(400.0, 50.0), (50.0, 10.0)]:
+        tf = ExponentialTransferFunction(width=w)
+        base = quasisep.Exp(scale=tau)
+        convolved_kernel = ConvolvedKernel(base, tf, n_grid=2000, truncation_factor=6.0)
+
+        for lag in lags:
+            expected = _analytic_convolved_exp(lag, tau, w)
+            actual = convolved_kernel.evaluate(lag, jnp.array(0.0))
+            assert_allclose(
+                actual, expected, atol=1e-2, err_msg=f"Failed for tau={tau} and w={w}"
+            )
+
+
+@pytest.mark.parametrize("shift", [0.0, 100.0, 500.0])
+def test_convolved_kernel_shift_invariance(shift):
+    """Check that ConvolvedKernel gives the same result regardless of shift."""
+    lags = jnp.array([0.0, 10.0, 50.0, 200.0])
+    tau, w = 50.0, 10.0
+    base = quasisep.Exp(scale=tau)
+
+    tf_ref = ExponentialTransferFunction(width=w)
+    ck_ref = ConvolvedKernel(base, tf_ref, n_grid=80, truncation_factor=6.0)
+
+    tf_shifted = ExponentialTransferFunction(width=w, shift=shift)
+    ck_shifted = ConvolvedKernel(base, tf_shifted, n_grid=80, truncation_factor=6.0)
+
+    for lag in lags:
+        expected = ck_ref.evaluate(lag, jnp.array(0.0))
+        actual = ck_shifted.evaluate(lag, jnp.array(0.0))
+        assert_allclose(actual, expected, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "transfer_function",
+    [
+        GaussianTransferFunction(width=10.0),
+        GaussianTransferFunction(width=50.0, shift=20.0),
+        ExponentialTransferFunction(width=10.0, shift=5.0),
+        ExponentialTransferFunction(width=50.0),
+        CausalGaussianTransferFunction(width=10.0),
+        CausalGaussianTransferFunction(width=50.0, shift=30.0),
+        CausalExponentialTransferFunction(width=10.0, shift=10.0),
+        CausalExponentialTransferFunction(width=50.0),
+    ],
+    ids=lambda tf: f"{type(tf).__name__}(w={tf.width},s={tf.shift})",
+)
+def test_transfer_function_normalization(transfer_function: TransferFunction):
+    """Check that ∫₋∞^∞ Ψ(s) ds = 1 for all transfer functions."""
+    center = float(transfer_function.shift)
+    hw = 10.0 * transfer_function.width
+    s = jnp.linspace(center - hw, center + hw, 10_000)
+    psi = transfer_function.evaluate(jnp.zeros_like(s), s)
+    result = jnp.trapezoid(psi, s)
+    assert_allclose(result, jnp.array(1.0), atol=1e-4)


### PR DESCRIPTION
This PR introduces `TransferFunction` and `ConvolvedKernel` classes. `TransferFunction` represents an arbitrary convolution kernel (not GP kernel) as a function of time interval. I added a few simple functions, all normalized to unity. `ConvolvedKernel` is a convolution of a GP kernel and a `TransferFunction` instance. Right now only `Quasisep` kernels are supported because they implement the `.power()` method used for FFT-based numerical convolution.