### PR TITLE
Mergesort for lag transfer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,8 @@ extensions = ["sphinx.ext.mathjax", "sphinx.ext.napoleon", "sphinx.ext.viewcode"
 extensions.append("autoapi.extension")
 extensions.append("nbsphinx")
 
+nbsphinx_kernel_name = "python3"
+
 # -- sphinx-copybutton configuration ----------------------------------------
 extensions.append("sphinx_copybutton")
 ## sets up the expected prompt text from console blocks, and excludes it from

--- a/docs/notebooks/01_DRW.ipynb
+++ b/docs/notebooks/01_DRW.ipynb
@@ -186,10 +186,10 @@
     "def initSampler():\n",
     "    # GP kernel param\n",
     "    log_drw_scale = numpyro.sample(\n",
-    "        \"drw_scale\", dist.Uniform(jnp.log(0.01), jnp.log(1000))\n",
+    "        \"log_drw_scale\", dist.Uniform(jnp.log(0.01), jnp.log(1000))\n",
     "    )\n",
     "    log_drw_sigma = numpyro.sample(\n",
-    "        \"drw_sigma\", dist.Uniform(jnp.log(0.01), jnp.log(10))\n",
+    "        \"log_drw_sigma\", dist.Uniform(jnp.log(0.01), jnp.log(10))\n",
     "    )\n",
     "    log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])\n",
     "    numpyro.deterministic(\"log_kernel_param\", log_kernel_param)\n",
@@ -234,6 +234,7 @@
     "sampler = initSampler\n",
     "fit_key = jax.random.PRNGKey(1)\n",
     "nSample = 10_000\n",
+    "\n",
     "nBest = 10  # it seems like this number needs to be high\n",
     "\n",
     "bestP, ll = random_search(model, initSampler, fit_key, nSample, nBest)\n",
@@ -279,27 +280,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def numpyro_model(t, yerr, y=None):\n",
-    "    # GP kernel param\n",
-    "    log_drw_scale = numpyro.sample(\n",
-    "        \"log_drw_scale\", dist.Uniform(jnp.log(0.01), jnp.log(1000))\n",
-    "    )\n",
-    "    log_drw_sigma = numpyro.sample(\n",
-    "        \"log_drw_sigma\", dist.Uniform(jnp.log(0.01), jnp.log(10))\n",
-    "    )\n",
-    "    log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])\n",
-    "    numpyro.deterministic(\"log_kernel_param\", log_kernel_param)\n",
-    "\n",
-    "    # mean: use a normal prior for better convergence\n",
-    "    mean = numpyro.sample(\"mean\", dist.Normal(0.0, 0.1))\n",
-    "\n",
-    "    sample_params = {\"log_kernel_param\": log_kernel_param, \"mean\": mean}\n",
-    "\n",
-    "    # the following is different from the initSampler\n",
-    "    zero_mean = False\n",
-    "\n",
-    "    k = Exp(scale=100.0, sigma=1.0)  # init params for k are not used\n",
-    "    m = UniVarModel(sim_t, sim_y_noisy, sim_yerr, k, zero_mean=zero_mean)\n",
+    "def numpyro_model(m, t, yerr, y=None):\n",
+    "    sample_params = initSampler()\n",
     "    m.sample(sample_params)"
    ]
   },
@@ -311,6 +293,10 @@
    "outputs": [],
    "source": [
     "%%time\n",
+    "zero_mean = False\n",
+    "k = Exp(scale=100.0, sigma=1.0)  # init params for k are not used\n",
+    "m = UniVarModel(sim_t, sim_y_noisy, sim_yerr, k, zero_mean=zero_mean)\n",
+    "\n",
     "nuts_kernel = NUTS(\n",
     "    numpyro_model,\n",
     "    dense_mass=True,\n",
@@ -327,7 +313,8 @@
     ")\n",
     "\n",
     "mcmc_seed = 0\n",
-    "mcmc.run(jax.random.PRNGKey(mcmc_seed), sim_t, sim_yerr, y=sim_y_noisy)\n",
+    "mcmc.run(jax.random.PRNGKey(mcmc_seed), m, sim_t, sim_yerr, y=sim_y_noisy)\n",
+    "\n",
     "data = az.from_numpyro(mcmc)\n",
     "mcmc.print_summary()"
    ]
@@ -510,14 +497,6 @@
     "plt.xlabel(\"Frequency\")\n",
     "plt.ylabel(\"PSD\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f92b0a1e-38fe-4187-9b67-5fe1b717129c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -525,9 +504,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "eztaox",
    "language": "python",
-   "name": "python3"
+   "name": "eztaox"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/01_DRW.ipynb
+++ b/docs/notebooks/01_DRW.ipynb
@@ -504,9 +504,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "eztaox",
    "language": "python",
-   "name": "python3"
+   "name": "eztaox"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/01_DRW.ipynb
+++ b/docs/notebooks/01_DRW.ipynb
@@ -504,9 +504,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "eztaox",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "eztaox"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/02_Multiband.ipynb
+++ b/docs/notebooks/02_Multiband.ipynb
@@ -664,9 +664,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "eztaox",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "eztaox"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/02_Multiband.ipynb
+++ b/docs/notebooks/02_Multiband.ipynb
@@ -239,10 +239,10 @@
     "def initSampler():\n",
     "    # GP kernel param\n",
     "    log_drw_scale = numpyro.sample(\n",
-    "        \"drw_scale\", dist.Uniform(jnp.log(0.01), jnp.log(1000))\n",
+    "        \"log_drw_scale\", dist.Uniform(jnp.log(0.01), jnp.log(1000))\n",
     "    )\n",
     "    log_drw_sigma = numpyro.sample(\n",
-    "        \"drw_sigma\", dist.Uniform(jnp.log(0.01), jnp.log(10))\n",
+    "        \"log_drw_sigma\", dist.Uniform(jnp.log(0.01), jnp.log(10))\n",
     "    )\n",
     "    log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])\n",
     "    numpyro.deterministic(\"log_kernel_param\", log_kernel_param)\n",
@@ -343,7 +343,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def numpyro_model(X, yerr, y=None):\n",
+    "def numpyro_model(m, X, yerr, y=None):\n",
     "    # GP kernel param\n",
     "    log_drw_scale = numpyro.sample(\n",
     "        \"log_drw_scale\", dist.Uniform(jnp.log(0.01), jnp.log(1000))\n",
@@ -371,14 +371,6 @@
     "        \"mean\": mean,\n",
     "        \"lag\": lag,\n",
     "    }\n",
-    "\n",
-    "    ## the following is different from the initSampler\n",
-    "    has_lag = True\n",
-    "    zero_mean = True\n",
-    "    nBand = 2\n",
-    "\n",
-    "    k = Exp(scale=100.0, sigma=1.0)  # init params for k are not used\n",
-    "    m = MultiVarModel(X, y, yerr, k, nBand, has_lag=has_lag, zero_mean=zero_mean)\n",
     "    m.sample(sample_params)"
    ]
   },
@@ -409,6 +401,14 @@
    "outputs": [],
    "source": [
     "%%time\n",
+    "## the following is different from the initSampler\n",
+    "has_lag = True\n",
+    "zero_mean = True\n",
+    "nBand = 2\n",
+    "\n",
+    "k = Exp(scale=100.0, sigma=1.0)  # init params for k are not used\n",
+    "m = MultiVarModel(X, y, yerr, k, nBand, has_lag=has_lag, zero_mean=zero_mean)\n",
+    "\n",
     "nuts_kernel = NUTS(\n",
     "    numpyro_model,\n",
     "    dense_mass=True,\n",
@@ -425,7 +425,7 @@
     ")\n",
     "\n",
     "mcmc_seed = 0\n",
-    "mcmc.run(jax.random.PRNGKey(mcmc_seed), X, yerr, y=y)\n",
+    "mcmc.run(jax.random.PRNGKey(mcmc_seed), m, X, yerr, y=y)\n",
     "data = az.from_numpyro(mcmc)\n",
     "mcmc.print_summary()"
    ]
@@ -664,9 +664,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "eztaox",
    "language": "python",
-   "name": "python3"
+   "name": "eztaox"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/03_DHO.ipynb
+++ b/docs/notebooks/03_DHO.ipynb
@@ -94,8 +94,8 @@
     "\n",
     "# simulation configurations\n",
     "lc_seed = 2\n",
-    "random_seed = 2\n",
-    "noise_seed = 11\n",
+    "random_seed = 3\n",
+    "noise_seed = 12\n",
     "min_dt, max_dt = 1, 3650.0\n",
     "\n",
     "# simulate\n",
@@ -282,7 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def numpyro_model(t, yerr, y=None):\n",
+    "def numpyro_model(m, t, yerr, y=None):\n",
     "    log_alpha = numpyro.sample(\n",
     "        \"log_alpha\", dist.Uniform(low=-16.0, high=0.0).expand([2])\n",
     "    )\n",
@@ -296,15 +296,6 @@
     "\n",
     "    sample_params = {\"log_kernel_param\": log_kernel_param, \"mean\": mean}\n",
     "\n",
-    "    # the following is different from the initSampler\n",
-    "    zero_mean = False\n",
-    "    p = 2\n",
-    "\n",
-    "    k = CARMA.init(\n",
-    "        jnp.exp(test_params[\"log_kernel_param\"][:p]),\n",
-    "        jnp.exp(test_params[\"log_kernel_param\"][p:]),\n",
-    "    )\n",
-    "    m = UniVarModel(sim_t, sim_y_noisy, sim_yerr, k, zero_mean=zero_mean)\n",
     "    m.sample(sample_params)"
    ]
   },
@@ -316,6 +307,17 @@
    "outputs": [],
    "source": [
     "%%time\n",
+    "\n",
+    "# the following is different from the initSampler\n",
+    "zero_mean = False\n",
+    "p = 2\n",
+    "\n",
+    "k = CARMA.init(\n",
+    "    jnp.exp(test_params[\"log_kernel_param\"][:p]),\n",
+    "    jnp.exp(test_params[\"log_kernel_param\"][p:]),\n",
+    ")\n",
+    "m = UniVarModel(sim_t, sim_y_noisy, sim_yerr, k, zero_mean=zero_mean)\n",
+    "\n",
     "nuts_kernel = NUTS(\n",
     "    numpyro_model,\n",
     "    dense_mass=True,\n",
@@ -332,7 +334,7 @@
     ")\n",
     "\n",
     "mcmc_seed = 0\n",
-    "mcmc.run(jax.random.PRNGKey(mcmc_seed), sim_t, sim_yerr, y=sim_y_noisy)\n",
+    "mcmc.run(jax.random.PRNGKey(mcmc_seed), m, sim_t, sim_yerr, y=sim_y_noisy)\n",
     "data = az.from_numpyro(mcmc)\n",
     "mcmc.print_summary()"
    ]
@@ -529,9 +531,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "eztaox",
    "language": "python",
-   "name": "python3"
+   "name": "eztaox"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/03_DHO.ipynb
+++ b/docs/notebooks/03_DHO.ipynb
@@ -531,9 +531,9 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "eztaox",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "eztaox"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -97,11 +97,13 @@ class MultiVarModel(eqx.Module):
 
         # assign band indexs for sorting the input time axis after lag transform
         sorted_t, sorted_band = self.X
+        unique_bands = jnp.unique(sorted_band)
+
         self.t_in_bands = [
-            sorted_t[jnp.where(sorted_band == i)[0]] for i in range(nBand)
+            sorted_t[jnp.where(sorted_band == i)[0]] for i in unique_bands
         ]
         self.concat_inds_in_bands = jnp.concat(
-            [jnp.where(sorted_band == i)[0] for i in range(nBand)]
+            [jnp.where(sorted_band == i)[0] for i in unique_bands]
         )
 
         # assign callables/classes

--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -12,7 +12,6 @@ import jax.flatten_util
 import jax.numpy as jnp
 import numpyro
 import tinygp.kernels as tk
-import tinygp.kernels.quasisep as tkq
 from numpy.typing import NDArray
 from tinygp import GaussianProcess
 from tinygp.helpers import JAXArray
@@ -57,7 +56,7 @@ class MultiVarModel(eqx.Module):
     y: JAXArray
     diag: JAXArray
     base_kernel_def: Callable
-    multiband_kernel: tk.Kernel | tkq.Wrapper
+    multiband_kernel: tk.Kernel | tk.quasisep.Wrapper
     nBand: int
     mean_func: Callable | None
     amp_scale_func: Callable | None
@@ -73,7 +72,7 @@ class MultiVarModel(eqx.Module):
         yerr: JAXArray | NDArray,
         base_kernel: tk.Kernel | quasisep.Quasisep,
         nBand: int,
-        multiband_kernel: tk.Kernel | tkq.Wrapper | None = None,
+        multiband_kernel: tk.Kernel | tk.quasisep.Wrapper | None = None,
         mean_func: Callable | None = None,
         amp_scale_func: Callable | None = None,
         lag_func: Callable | None = None,
@@ -81,21 +80,21 @@ class MultiVarModel(eqx.Module):
     ) -> None:
         # format inputs
         t = jnp.asarray(X[0])
-        inds = jnp.argsort(t)
         band = jnp.asarray(X[1], dtype=int)
         y = jnp.asarray(y)
         yerr = jnp.asarray(yerr)
+        init_inds = jnp.argsort(t)
 
         # assign attributes
-        self.X = (t[inds], band[inds])
-        self.diag = (yerr**2)[inds]
-        self.y = y[inds]
+        self.X = (t[init_inds], band[init_inds])
+        self.diag = (yerr**2)[init_inds]
+        self.y = y[init_inds]
         self.base_kernel_def = jax.flatten_util.ravel_pytree(base_kernel)[1]
         self.nBand = nBand
 
         # assign callables/classes
         if multiband_kernel is None:
-            if isinstance(base_kernel, quasisep.Quasisep):
+            if isinstance(base_kernel, tk.quasisep.Quasisep):
                 multiband_kernel = quasisep.MultibandLowRank
             else:
                 multiband_kernel = direct.MultibandLowRank
@@ -272,7 +271,7 @@ class MultiVarModel(eqx.Module):
             "diag": diags[inds],
             "mean": means,
         }
-        if isinstance(kernel, tkq.Quasisep):
+        if isinstance(kernel, tk.quasisep.Quasisep):
             gp_kwargs["assume_sorted"] = True
 
         return (
@@ -310,7 +309,7 @@ class UniVarModel(MultiVarModel):
         t: JAXArray | NDArray,
         y: JAXArray | NDArray,
         yerr: JAXArray | NDArray,
-        kernel: tk.Kernel | quasisep.Quasisep,
+        kernel: tk.Kernel | tk.quasisep.Quasisep,
         mean_func: Callable | None = None,
         amp_scale_func: Callable | None = None,
         **kwargs,

--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -59,7 +59,7 @@ class MultiVarModel(eqx.Module):
     base_kernel_def: Callable
     multiband_kernel: tk.Kernel | tk.quasisep.Wrapper
     t_in_bands: list[JAXArray]
-    inds_in_bands: list[JAXArray]
+    concat_inds_in_bands: list[JAXArray]
     nBand: int
     mean_func: Callable | None
     amp_scale_func: Callable | None
@@ -97,8 +97,12 @@ class MultiVarModel(eqx.Module):
 
         # assign band indexs for sorting the input time axis after lag transform
         sorted_t, sorted_band = self.X
-        self.t_in_bands = [sorted_t[sorted_band == i] for i in range(nBand)]
-        self.inds_in_bands = [jnp.where(sorted_band == i)[0] for i in range(nBand)]
+        self.t_in_bands = [
+            sorted_t[jnp.where(sorted_band == i)[0]] for i in range(nBand)
+        ]
+        self.concat_inds_in_bands = jnp.concat(
+            [jnp.where(sorted_band == i)[0] for i in range(nBand)]
+        )
 
         # assign callables/classes
         if multiband_kernel is None:
@@ -149,9 +153,10 @@ class MultiVarModel(eqx.Module):
         new_t = t - lags[band]
 
         # use merge sort to get the sorted indices for the new time after lag transform
-        shifted_t_in_bands = [time - lags[i] for i, time in enumerate(self.t_in_bands)]
-        concat_inds = jnp.concatenate(self.inds_in_bands)
-        inds = concat_inds[merge_sort(*shifted_t_in_bands)]
+        shifted_t_in_bands = jax.tree_util.tree_map(
+            lambda time, lag: time - lag, self.t_in_bands, list(lags)
+        )
+        inds = self.concat_inds_in_bands[merge_sort(*shifted_t_in_bands)]
 
         return (new_t, band), inds
 
@@ -269,6 +274,7 @@ class MultiVarModel(eqx.Module):
     ) -> tuple[tuple[JAXArray, JAXArray], JAXArray]:
         return jnp.insert(jnp.atleast_1d(params["lag"]), 0, 0.0)
 
+    # @eqx.filter_jit
     def _build_gp(
         self, params: dict[str, JAXArray]
     ) -> tuple[GaussianProcess, JAXArray]:

--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -17,6 +17,7 @@ from tinygp import GaussianProcess
 from tinygp.helpers import JAXArray
 
 from eztaox.kernels import direct, quasisep
+from eztaox.ts_utils import merge_sort
 
 
 class MultiVarModel(eqx.Module):
@@ -57,6 +58,7 @@ class MultiVarModel(eqx.Module):
     diag: JAXArray
     base_kernel_def: Callable
     multiband_kernel: tk.Kernel | tk.quasisep.Wrapper
+    t_in_bands: list[JAXArray]
     nBand: int
     mean_func: Callable | None
     amp_scale_func: Callable | None
@@ -91,6 +93,12 @@ class MultiVarModel(eqx.Module):
         self.y = y[init_inds]
         self.base_kernel_def = jax.flatten_util.ravel_pytree(base_kernel)[1]
         self.nBand = nBand
+
+        # assign band indexs for sorting the input time axis after lag transform
+        t_in_bands = []
+        for i in range(nBand):
+            t_in_bands.append(t[band == i])
+        self.t_in_bands = t_in_bands
 
         # assign callables/classes
         if multiband_kernel is None:
@@ -139,7 +147,10 @@ class MultiVarModel(eqx.Module):
 
         t, band = X
         new_t = t - lags[band]
-        inds = jnp.argsort(new_t)
+        # inds = jnp.argsort(new_t)
+        inds = merge_sort(
+            jax.tree.map(lambda time, lag: time - lag, self.t_in_bands, lags)
+        )
         return (new_t, band), inds
 
     def log_prior(self, params: dict[str, JAXArray]) -> JAXArray:

--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -59,6 +59,7 @@ class MultiVarModel(eqx.Module):
     base_kernel_def: Callable
     multiband_kernel: tk.Kernel | tk.quasisep.Wrapper
     t_in_bands: list[JAXArray]
+    inds_in_bands: list[JAXArray]
     nBand: int
     mean_func: Callable | None
     amp_scale_func: Callable | None
@@ -95,10 +96,9 @@ class MultiVarModel(eqx.Module):
         self.nBand = nBand
 
         # assign band indexs for sorting the input time axis after lag transform
-        t_in_bands = []
-        for i in range(nBand):
-            t_in_bands.append(t[band == i])
-        self.t_in_bands = t_in_bands
+        sorted_t, sorted_band = self.X
+        self.t_in_bands = [sorted_t[sorted_band == i] for i in range(nBand)]
+        self.inds_in_bands = [jnp.where(sorted_band == i)[0] for i in range(nBand)]
 
         # assign callables/classes
         if multiband_kernel is None:
@@ -134,6 +134,27 @@ class MultiVarModel(eqx.Module):
             return self.amp_scale_func(params)
         return self._default_amp_scale_func(params)
 
+    def _lag_transform_fast(
+        self, has_lag: bool, params: dict[str, JAXArray]
+    ) -> tuple[tuple[JAXArray, JAXArray], JAXArray]:
+        """Shift the time axis by the lag in each band. Fast version used in fitting."""
+        if has_lag is False:
+            lags = jnp.zeros(self.nBand)
+        elif self.lag_func is not None:
+            lags = self.lag_func(params)
+        else:
+            lags = self._default_lag_func(params)
+
+        t, band = self.X
+        new_t = t - lags[band]
+
+        # use merge sort to get the sorted indices for the new time after lag transform
+        shifted_t_in_bands = [time - lags[i] for i, time in enumerate(self.t_in_bands)]
+        concat_inds = jnp.concatenate(self.inds_in_bands)
+        inds = concat_inds[merge_sort(*shifted_t_in_bands)]
+
+        return (new_t, band), inds
+
     def lag_transform(
         self, has_lag: bool, params: dict[str, JAXArray], X: JAXArray
     ) -> tuple[tuple[JAXArray, JAXArray], JAXArray]:
@@ -147,10 +168,8 @@ class MultiVarModel(eqx.Module):
 
         t, band = X
         new_t = t - lags[band]
-        # inds = jnp.argsort(new_t)
-        inds = merge_sort(
-            jax.tree.map(lambda time, lag: time - lag, self.t_in_bands, lags)
-        )
+        inds = jnp.argsort(new_t)
+
         return (new_t, band), inds
 
     def log_prior(self, params: dict[str, JAXArray]) -> JAXArray:
@@ -259,7 +278,7 @@ class MultiVarModel(eqx.Module):
 
         # time axis transform: t and band are not sorted,
         # inds gives the sorted indices for the new_t
-        X, inds = self.lag_transform(self.has_lag, params, self.X)
+        X, inds = self._lag_transform_fast(self.has_lag, params)
         t = X[0]
         band = X[1]
 
@@ -349,8 +368,8 @@ class UniVarModel(MultiVarModel):
     def _default_amp_scale_func(self, params: dict[str, JAXArray]) -> JAXArray:
         return jnp.array([0.0])
 
-    def lag_transform(  # noqa: D102
-        self, has_lag, params, X
+    def _lag_transform_fast(  # noqa: D102
+        self, has_lag, params
     ) -> tuple[tuple[JAXArray, JAXArray], JAXArray]:
         # TODO: Write docstring.
         return self.X, jnp.arange(self.X[0].size)

--- a/src/eztaox/simulator.py
+++ b/src/eztaox/simulator.py
@@ -8,7 +8,6 @@ import jax
 import jax.flatten_util
 import jax.numpy as jnp
 import tinygp.kernels as tk
-import tinygp.kernels.quasisep as tkq
 from numpy.typing import NDArray
 from tinygp import GaussianProcess
 from tinygp.helpers import JAXArray
@@ -47,7 +46,7 @@ class MultiVarSim(eqx.Module):
     """
 
     base_kernel_def: Callable
-    multiband_kernel: tk.Kernel | tkq.Wrapper
+    multiband_kernel: tk.Kernel | tk.quasisep.Wrapper
     X: tuple[JAXArray, JAXArray]
     init_params: dict[str, JAXArray]
     nBand: int
@@ -59,12 +58,12 @@ class MultiVarSim(eqx.Module):
 
     def __init__(
         self,
-        base_kernel: tk.Kernel | quasisep.Quasisep,
+        base_kernel: tk.Kernel | tk.quasisep.Quasisep,
         min_dt: float,
         max_dt: float,
         nBand: int,
         init_params: dict[str, JAXArray],
-        multiband_kernel: tk.Kernel | tkq.Wrapper | None = None,
+        multiband_kernel: tk.Kernel | tk.quasisep.Wrapper | None = None,
         mean_func: Callable | None = None,
         amp_scale_func: Callable | None = None,
         lag_func: Callable | None = None,
@@ -88,7 +87,7 @@ class MultiVarSim(eqx.Module):
         # assign callables/classes
         self.base_kernel_def = jax.flatten_util.ravel_pytree(base_kernel)[1]
         if multiband_kernel is None:
-            if isinstance(base_kernel, quasisep.Quasisep):
+            if isinstance(base_kernel, tk.quasisep.Quasisep):
                 multiband_kernel = quasisep.MultibandLowRank
             else:
                 multiband_kernel = direct.MultibandLowRank
@@ -259,7 +258,7 @@ class MultiVarSim(eqx.Module):
         gp_kwargs = dict(mean=means)
 
         # Only QuasisepSolver supports assume_sorted in tinygp
-        if isinstance(kernel, tkq.Quasisep):
+        if isinstance(kernel, tk.quasisep.Quasisep):
             gp_kwargs["assume_sorted"] = True
 
         return (
@@ -336,7 +335,7 @@ class UniVarSim(MultiVarSim):
 
     def __init__(
         self,
-        base_kernel: tk.Kernel | quasisep.Quasisep,
+        base_kernel: tk.Kernel | tk.quasisep.Quasisep,
         min_dt: float,
         max_dt: float,
         init_params: dict[str, JAXArray],

--- a/src/eztaox/ts_utils.py
+++ b/src/eztaox/ts_utils.py
@@ -84,3 +84,99 @@ def add_noise(y: JAXArray, yerr: JAXArray, key: jax.random.PRNGKey) -> JAXArray:
     noise = jax.random.normal(key, shape=y.shape, dtype=y.dtype) * yerr
 
     return y + noise
+
+
+def merge_two_sorted_argsort(a, b):
+    """Merge two sorted arrays and return the argsort permutation.
+
+    Args:
+        a (JAXArray): First sorted array.
+        b (JAXArray): Second sorted array.
+
+    Returns:
+        JAXArray: Indices that would sort the concatenation of ``a`` and ``b``.
+    """
+    a = jnp.asarray(a)
+    b = jnp.asarray(b)
+    n = a.shape[0]
+    m = b.shape[0]
+    N = n + m
+
+    perm = jnp.empty((N,), dtype=jnp.int32)
+
+    def body(k, carry):
+        i, j, perm = carry
+        a_valid = i < n
+        b_valid = j < m
+
+        ai = jnp.where(a_valid, a[i], 0)
+        bj = jnp.where(b_valid, b[j], 0)
+
+        take_a = a_valid & (~b_valid | (ai <= bj))
+        idx = jnp.where(take_a, i, n + j)
+        perm = perm.at[k].set(idx)
+
+        i = i + take_a.astype(jnp.int32)
+        j = j + (~take_a).astype(jnp.int32)
+        return i, j, perm
+
+    _, _, perm = jax.lax.fori_loop(0, N, body, (jnp.int32(0), jnp.int32(0), perm))
+    return perm
+
+
+def merge_many_sorted_argsort(arrays):
+    """Merge multiple sorted arrays and return the argsort permutation.
+
+    Args:
+        arrays (list[JAXArray]): List of sorted arrays to merge.
+
+    Returns:
+        JAXArray: Indices that would sort the concatenation of all input arrays.
+    """
+    arrays = [jnp.asarray(a) for a in arrays]
+    if len(arrays) == 0:
+        return jnp.array([], dtype=jnp.int32)
+
+    lengths = [a.shape[0] for a in arrays]
+    offsets = []
+    s = 0
+    for n in lengths:
+        offsets.append(s)
+        s += n
+
+    items = [
+        (a, jnp.arange(a.shape[0], dtype=jnp.int32) + off)
+        for a, off in zip(arrays, offsets, strict=True)
+    ]
+
+    while len(items) > 1:
+        new_items = []
+        for i in range(0, len(items), 2):
+            if i + 1 == len(items):
+                new_items.append(items[i])
+            else:
+                av, ai = items[i]
+                bv, bi = items[i + 1]
+                p = merge_two_sorted_argsort(av, bv)
+                new_items.append(
+                    (
+                        jnp.concatenate([av, bv])[p],
+                        jnp.concatenate([ai, bi])[p],
+                    )
+                )
+        items = new_items
+
+    return items[0][1]
+
+
+@jax.jit
+def merge_sort(*arrays) -> JAXArray:
+    """Merge multiple sorted arrays and return the argsort permutation.
+
+    Args:
+        *arrays: Variable number of sorted arrays to merge.
+
+    Returns:
+        JAXArray: Indices that would sort the concatenation of all input arrays.
+    """
+    return merge_many_sorted_argsort(list(arrays))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import jax
+import numpy as np
 import pytest
 
 DATA_DIR_NAME = "data"
@@ -8,8 +9,12 @@ TEST_DIR = os.path.dirname(__file__)
 
 
 @pytest.fixture
-def test_data_dir() -> str:
-    return os.path.join(TEST_DIR, DATA_DIR_NAME)
+def test_data() -> dict[str, np.ndarray]:
+    test_data_dir = os.path.join(TEST_DIR, DATA_DIR_NAME)
+
+    # load test data
+    data = np.load(test_data_dir + "/unit_test_lc.npz")
+    return data
 
 
 @pytest.fixture

--- a/tests/eztaox/test_fitter.py
+++ b/tests/eztaox/test_fitter.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpyro
 from joblib import Parallel, delayed
 from numpyro import distributions as dist
+from numpyro.infer import MCMC, NUTS, init_to_median
 from scipy.stats import median_abs_deviation as mad
 
 from eztaox.fitter import random_search, random_search_adam
@@ -47,7 +48,6 @@ def test_multivar_drw(test_data, basekey_seed) -> None:
     """
 
     # load test data
-    # data = np.load(test_data_dir + "/unit_test_lc.npz")
     ts = test_data["ts"]
     bands = test_data["bands"]
     ys = test_data["ys"]
@@ -115,7 +115,6 @@ def test_multivar_drw_adam(test_data, basekey_seed) -> None:
     """
 
     # load test data
-    # data = np.load(test_data_dir + "/unit_test_lc.npz")
     ts = test_data["ts"]
     bands = test_data["bands"]
     ys = test_data["ys"]
@@ -174,4 +173,51 @@ def test_multivar_drw_adam(test_data, basekey_seed) -> None:
     assert np.mean(np.abs(np.asarray(lag_diff))) < 2.0
 
 
-# def test_multivar_drw_mcmc()
+def test_multivar_drw_mcmc(test_data, basekey_seed) -> None:
+    """
+    Test multivariate DRW fitting with MCMC.
+    """
+
+    # load test data
+    ts = test_data["ts"]
+    bands = test_data["bands"]
+    ys = test_data["ys"]
+
+    # define model parameters
+    has_lag = True  # True: Fit for inter-band lag
+    zero_mean = True  # True: Fit for light curve mean
+    nBand = 2  # number of bands in the provide light curve (X, y, yerr)
+    fit_bands = [0, 1]  # which bands to fit
+
+    # format input data for fitting, only use the specified bands for fitting
+    X = (
+        ts[0][np.isin(bands[0], fit_bands)],
+        bands[0][np.isin(bands[0], fit_bands)],
+    )
+    y = ys[0][np.isin(bands[0], fit_bands)]
+    yerr = jnp.ones_like(y) * 1e-6
+
+    def numpyro_model(m, X, yerr, y=None):
+        sample_params = initSampler()
+        m.sample(sample_params)
+
+    # initialize a GP kernel, note the initial parameters are not used in the fitting
+    k = Exp(scale=100.0, sigma=1.0)
+    m = MultiVarModel(X, y, yerr, k, nBand, has_lag=has_lag, zero_mean=zero_mean)
+
+    nuts_kernel = NUTS(
+        numpyro_model,
+        dense_mass=True,
+        target_accept_prob=0.9,
+        init_strategy=init_to_median,
+    )
+
+    mcmc = MCMC(
+        nuts_kernel,
+        num_warmup=500,
+        num_samples=1000,
+        num_chains=1,
+        progress_bar=False,
+    )
+
+    mcmc.run(jax.random.PRNGKey(basekey_seed), m, X, yerr, y=y)

--- a/tests/eztaox/test_fitter.py
+++ b/tests/eztaox/test_fitter.py
@@ -41,16 +41,16 @@ def initSampler():  # noqa: N802
     return sample_params
 
 
-def test_multivar_drw(test_data_dir, basekey_seed) -> None:
+def test_multivar_drw(test_data, basekey_seed) -> None:
     """
     Test multivariate DRW fitting.
     """
 
     # load test data
-    data = np.load(test_data_dir + "/unit_test_lc.npz")
-    ts = data["ts"]
-    bands = data["bands"]
-    ys = data["ys"]
+    # data = np.load(test_data_dir + "/unit_test_lc.npz")
+    ts = test_data["ts"]
+    bands = test_data["bands"]
+    ys = test_data["ys"]
 
     # config for fitting
     nSample = 10_000
@@ -109,44 +109,21 @@ def test_multivar_drw(test_data_dir, basekey_seed) -> None:
     assert mad(lag_diff, scale="normal") < 1
 
 
-def test_multivar_drw_adam(test_data_dir, basekey_seed) -> None:
+def test_multivar_drw_adam(test_data, basekey_seed) -> None:
     """
     Test multivariate DRW fitting with Adam refinement.
     """
 
     # load test data
-    data = np.load(test_data_dir + "/unit_test_lc.npz")
-    ts = data["ts"]
-    bands = data["bands"]
-    ys = data["ys"]
+    # data = np.load(test_data_dir + "/unit_test_lc.npz")
+    ts = test_data["ts"]
+    bands = test_data["bands"]
+    ys = test_data["ys"]
 
     # config for fitting
     nSample = 2_000
     nBest = 5
     fit_bands = [0, 1]
-
-    # # sampler function
-    # def initSampler():  # noqa: N802
-    #     log_drw_scale = numpyro.sample(
-    #         "drw_scale", dist.Uniform(jnp.log(0.1), jnp.log(10000))
-    #     )
-    #     log_drw_sigma = numpyro.sample(
-    #         "drw_sigma", dist.Uniform(jnp.log(0.01), jnp.log(2))
-    #     )
-    #     log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])
-    #     numpyro.deterministic("log_kernel_param", log_kernel_param)
-
-    #     log_amp_scale = numpyro.sample("log_amp_scale", dist.Uniform(-2, 2))
-    #     mean = numpyro.sample("mean", dist.Normal(loc=0.0, scale=0.1))
-    #     lag = numpyro.sample("lag", dist.Uniform(-10.0, 10.0))
-
-    #     sample_params = {
-    #         "log_kernel_param": log_kernel_param,
-    #         "log_amp_scale": log_amp_scale,
-    #         "mean": mean,
-    #         "lag": lag,
-    #     }
-    #     return sample_params
 
     def fit(X, y, yerr, nBand, basekey_seed, key_index):
         m = MultiVarModel(
@@ -196,4 +173,5 @@ def test_multivar_drw_adam(test_data_dir, basekey_seed) -> None:
     lag_diff = bestP_all["lag"] - true_params["lag"]
     assert np.mean(np.abs(np.asarray(lag_diff))) < 2.0
 
-    # def test_multivar_drw_mcmc()
+
+# def test_multivar_drw_mcmc()

--- a/tests/eztaox/test_fitter.py
+++ b/tests/eztaox/test_fitter.py
@@ -15,6 +15,32 @@ from eztaox.kernels.quasisep import Exp
 from eztaox.models import MultiVarModel
 
 
+# sampler function
+def initSampler():  # noqa: N802
+    # GP kernel param
+    log_drw_scale = numpyro.sample(
+        "drw_scale", dist.Uniform(jnp.log(0.1), jnp.log(10000))
+    )
+    log_drw_sigma = numpyro.sample("drw_sigma", dist.Uniform(jnp.log(0.01), jnp.log(2)))
+    log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])
+    numpyro.deterministic("log_kernel_param", log_kernel_param)
+
+    # amp scale
+    log_amp_scale = numpyro.sample("log_amp_scale", dist.Uniform(-2, 2))
+
+    # mean
+    mean = numpyro.sample("mean", dist.Normal(loc=0.0, scale=0.1))
+    lag = numpyro.sample("lag", dist.Uniform(-10.0, 10.0))
+
+    sample_params = {
+        "log_kernel_param": log_kernel_param,
+        "log_amp_scale": log_amp_scale,
+        "mean": mean,
+        "lag": lag,
+    }
+    return sample_params
+
+
 def test_multivar_drw(test_data_dir, basekey_seed) -> None:
     """
     Test multivariate DRW fitting.
@@ -30,33 +56,6 @@ def test_multivar_drw(test_data_dir, basekey_seed) -> None:
     nSample = 10_000
     nBest = 10
     fit_bands = [0, 1]
-
-    # sampler function
-    def initSampler():  # noqa: N802
-        # GP kernel param
-        log_drw_scale = numpyro.sample(
-            "drw_scale", dist.Uniform(jnp.log(0.1), jnp.log(10000))
-        )
-        log_drw_sigma = numpyro.sample(
-            "drw_sigma", dist.Uniform(jnp.log(0.01), jnp.log(2))
-        )
-        log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])
-        numpyro.deterministic("log_kernel_param", log_kernel_param)
-
-        # amp scale
-        log_amp_scale = numpyro.sample("log_amp_scale", dist.Uniform(-2, 2))
-
-        # mean
-        mean = numpyro.sample("mean", dist.Normal(loc=0.0, scale=0.1))
-        lag = numpyro.sample("lag", dist.Uniform(-10.0, 10.0))
-
-        sample_params = {
-            "log_kernel_param": log_kernel_param,
-            "log_amp_scale": log_amp_scale,
-            "mean": mean,
-            "lag": lag,
-        }
-        return sample_params
 
     # fit function for parallelization
     def fit(X, y, yerr, nBand, basekey_seed, key_index):
@@ -126,28 +125,28 @@ def test_multivar_drw_adam(test_data_dir, basekey_seed) -> None:
     nBest = 5
     fit_bands = [0, 1]
 
-    # sampler function
-    def initSampler():  # noqa: N802
-        log_drw_scale = numpyro.sample(
-            "drw_scale", dist.Uniform(jnp.log(0.1), jnp.log(10000))
-        )
-        log_drw_sigma = numpyro.sample(
-            "drw_sigma", dist.Uniform(jnp.log(0.01), jnp.log(2))
-        )
-        log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])
-        numpyro.deterministic("log_kernel_param", log_kernel_param)
+    # # sampler function
+    # def initSampler():  # noqa: N802
+    #     log_drw_scale = numpyro.sample(
+    #         "drw_scale", dist.Uniform(jnp.log(0.1), jnp.log(10000))
+    #     )
+    #     log_drw_sigma = numpyro.sample(
+    #         "drw_sigma", dist.Uniform(jnp.log(0.01), jnp.log(2))
+    #     )
+    #     log_kernel_param = jnp.stack([log_drw_scale, log_drw_sigma])
+    #     numpyro.deterministic("log_kernel_param", log_kernel_param)
 
-        log_amp_scale = numpyro.sample("log_amp_scale", dist.Uniform(-2, 2))
-        mean = numpyro.sample("mean", dist.Normal(loc=0.0, scale=0.1))
-        lag = numpyro.sample("lag", dist.Uniform(-10.0, 10.0))
+    #     log_amp_scale = numpyro.sample("log_amp_scale", dist.Uniform(-2, 2))
+    #     mean = numpyro.sample("mean", dist.Normal(loc=0.0, scale=0.1))
+    #     lag = numpyro.sample("lag", dist.Uniform(-10.0, 10.0))
 
-        sample_params = {
-            "log_kernel_param": log_kernel_param,
-            "log_amp_scale": log_amp_scale,
-            "mean": mean,
-            "lag": lag,
-        }
-        return sample_params
+    #     sample_params = {
+    #         "log_kernel_param": log_kernel_param,
+    #         "log_amp_scale": log_amp_scale,
+    #         "mean": mean,
+    #         "lag": lag,
+    #     }
+    #     return sample_params
 
     def fit(X, y, yerr, nBand, basekey_seed, key_index):
         m = MultiVarModel(
@@ -196,3 +195,5 @@ def test_multivar_drw_adam(test_data_dir, basekey_seed) -> None:
 
     lag_diff = bestP_all["lag"] - true_params["lag"]
     assert np.mean(np.abs(np.asarray(lag_diff))) < 2.0
+
+    # def test_multivar_drw_mcmc()

--- a/tests/eztaox/test_ts_utils.py
+++ b/tests/eztaox/test_ts_utils.py
@@ -122,3 +122,25 @@ def test_merge_sort() -> None:
     expected_perm = np.argsort(np.concatenate([t1, t2, t3]))
 
     assert np.array_equal(perm, expected_perm)
+
+
+def test_merge_sort_requires_index_remap_for_interleaved_inputs() -> None:
+    """Test that merge_sort indices must be remapped for observation-order arrays."""
+
+    t = np.array([1.0, 1.1, 2.0, 2.1, 3.0, 3.1])
+    band = np.array([0, 1, 0, 1, 0, 1])
+    lags = np.array([0.0, 1.5])
+
+    new_t = t - lags[band]
+    expected_perm = np.argsort(new_t)
+
+    t_in_bands = [t[band == i] for i in range(2)]
+    inds_in_bands = [np.where(band == i)[0] for i in range(2)]
+    shifted_t_in_bands = [time - lags[i] for i, time in enumerate(t_in_bands)]
+
+    naive_perm = np.array(merge_sort(*shifted_t_in_bands))
+    concat_inds = np.concatenate(inds_in_bands)
+    remapped_perm = concat_inds[naive_perm]
+
+    assert not np.array_equal(naive_perm, expected_perm)
+    assert np.array_equal(remapped_perm, expected_perm)

--- a/tests/eztaox/test_ts_utils.py
+++ b/tests/eztaox/test_ts_utils.py
@@ -2,7 +2,13 @@
 
 import numpy as np
 
-from eztaox.ts_utils import _get_nearest_idx, add_noise, downsampleByTime, formatlc
+from eztaox.ts_utils import (
+    _get_nearest_idx,
+    add_noise,
+    downsampleByTime,
+    formatlc,
+    merge_sort,
+)
 
 
 def test_get_nearest_idx() -> None:
@@ -101,3 +107,18 @@ def test_addNoise() -> None:  # noqa: N802
 
     print(res.pvalue)
     assert res.pvalue > 0.05  # Fail if p-value < 5%
+
+
+def test_merge_sort() -> None:
+    """Test that the merge_sort gives consistent results as jnp.argsort."""
+
+    r = np.random.default_rng(49382)
+    t1 = np.sort(r.uniform(0, 10, 10_000))
+    t2 = np.sort(r.uniform(0, 10, 2_000))
+    t3 = np.sort(r.uniform(0, 10, 100))
+
+    # Test merge_sort
+    perm = merge_sort(t1, t2, t3)
+    expected_perm = np.argsort(np.concatenate([t1, t2, t3]))
+
+    assert np.array_equal(perm, expected_perm)


### PR DESCRIPTION
## Change Description
Replace jax.argsort with custom merge sort to speed likelihood evaluation in lag inference. Now the time spend on sorting per likelihood evaluation should be negligible compared to GP log_prob.

## Solution Description


## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
