### PR TITLE
Model cleanup

### DIFF
--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -273,6 +273,7 @@ class MultiVarModel(eqx.Module):
     ) -> tuple[tuple[JAXArray, JAXArray], JAXArray]:
         return jnp.insert(jnp.atleast_1d(params["lag"]), 0, 0.0)
 
+    @eqx.filter_jit
     def _build_gp(
         self, params: dict[str, JAXArray]
     ) -> tuple[GaussianProcess, JAXArray]:

--- a/src/eztaox/models.py
+++ b/src/eztaox/models.py
@@ -191,20 +191,6 @@ class MultiVarModel(eqx.Module):
 
         return (new_t, band), inds
 
-    def log_prior(self, params: dict[str, JAXArray]) -> JAXArray:
-        """Calculate the log prior of the input parameters.
-
-        Args:
-            params (dict[str, JAXArray]): Model parameters.
-
-        Returns:
-            JAXArray: Log prior of the input parameters.
-        """
-        # Assuming a Gaussian prior for demonstration purposes
-        log_prior = 0.0
-        return log_prior
-
-    @eqx.filter_jit
     def log_prob(self, params: dict[str, JAXArray]) -> JAXArray:
         """Calculate the log probability of the input parameters.
 
@@ -215,13 +201,13 @@ class MultiVarModel(eqx.Module):
             JAXArray: Log probability of the input parameters.
         """
         gp, inds = self._build_gp(params)
-        return gp.log_probability(y=self.y[inds]) + self.log_prior(params)
+        return gp.log_probability(y=self.y[inds])
 
     def aic(self, params: dict[str, JAXArray]) -> JAXArray:
         """Calculate the Akaike Information Criterion (AIC) for the model.
 
         Args:
-            params (dict[str, JAXArray]): Model parameters.
+            params (dict[str, JAXArray]): Maximum likelihood model parameters.
         Returns:
             JAXArray: AIC value.
         """
@@ -234,7 +220,7 @@ class MultiVarModel(eqx.Module):
         """Calculate the Bayesian Information Criterion (BIC) for the model.
 
         Args:
-            params (dict[str, JAXArray]): Model parameters.
+            params (dict[str, JAXArray]): Maximum likelihood model parameters.
         Returns:
             JAXArray: BIC value.
         """
@@ -253,7 +239,6 @@ class MultiVarModel(eqx.Module):
         gp, inds = self._build_gp(params)
         numpyro.sample("gp", gp.numpyro_dist(), obs=self.y[inds])
 
-    @eqx.filter_jit
     def pred(
         self, params: dict[str, JAXArray], X: JAXArray
     ) -> tuple[JAXArray, JAXArray]:
@@ -288,7 +273,6 @@ class MultiVarModel(eqx.Module):
     ) -> tuple[tuple[JAXArray, JAXArray], JAXArray]:
         return jnp.insert(jnp.atleast_1d(params["lag"]), 0, 0.0)
 
-    # @eqx.filter_jit
     def _build_gp(
         self, params: dict[str, JAXArray]
     ) -> tuple[GaussianProcess, JAXArray]:


### PR DESCRIPTION
## Change Description
1. Remove log_prior function that is not often used, priors can be added via other channels
2. remove jitter decorator for ~_build_gp and~ log_prob, which seems to slow down the performance a tiny bit

## Solution Description


## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
